### PR TITLE
Fixed sort order for attributes with manual sort

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Attribute.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Attribute.php
@@ -256,16 +256,16 @@ class Attribute extends \Magento\CatalogSearch\Model\Layer\Filter\Attribute impl
     private function addOptionsData(array $items)
     {
         if ($this->getAttributeModel()->getFacetSortOrder() == BucketInterface::SORT_ORDER_MANUAL) {
-            $options = $this->getAttributeModel()->getFrontend()->getSelectOptions();
+            $options = $this->getAttributeModel()->getFrontend()->getAttribute()->getSource()->getAllOptions(false);
             $optionPosition = 0;
 
             if (!empty($options)) {
                 foreach ($options as $option) {
                     if (isset($option['label'])) {
-                        $optionLabel = (string) $option['label'];
+                        $optionLabel = (string) trim($option['label']);
                         $optionPosition++;
 
-                        if ($optionLabel && isset($items[$optionLabel])) {
+                        if (($optionLabel === '0' || $optionLabel) && isset($items[$optionLabel])) {
                             $items[$optionLabel]['adminSortIndex'] = $optionPosition;
                             $items[$optionLabel]['value']          = $option['value'];
                         }


### PR DESCRIPTION
Issue: when adding "0" value option to a multiselect attribute the "$optionLabel" will be considered empty and "adminSortIndex" will not be set

Changes: 
1. Select attribute options without empty value as empty value is not used in layered navigation
2. Trim option label as options may contain spaces. In this case facet value is already trimmed and attribute option will not causing undefined index for "adminSortIndex" while usort().
3. Check if "$optionLabel" is "0" string as attribute options may contain "0" value